### PR TITLE
Update bounds for near-term nuclear-capacity thresholds

### DIFF
--- a/validate_data/feasible_nearterm_capacity_trends.yaml
+++ b/validate_data/feasible_nearterm_capacity_trends.yaml
@@ -16,8 +16,7 @@
   year: 2030
   validation:
     - warning_level: high
-      upper_bound: 479.92  # GW
-      lower_bound: 269.75  # GW
+      upper_bound: 507.1  # GW
     - warning_level: medium
       upper_bound: 441.92  # GW
       lower_bound: 320.33  # GW


### PR DESCRIPTION
Per email by @gunnar-pik, this PR updates the threshold for nuclear-capacity feasibility criteria and removes the explicit lower bound for the high-concern flag. This is for consistency with the validation and analysis in the ScenarioMIP workflow.

@zyankarli @PhilippVerpoort